### PR TITLE
fix: ci fails due to cache pull fail for the first time

### DIFF
--- a/yamls/devtron.yaml
+++ b/yamls/devtron.yaml
@@ -54,7 +54,7 @@ data:
   CD_NODE_TAINTS_VALUE: ""
   CD_ARTIFACT_LOCATION_FORMAT: "%d/%d.zip"
   DEFAULT_CD_NAMESPACE: "devtron-cd"
-  DEFAULT_CI_IMAGE: "quay.io/devtron/ci-runner:edbc923d-138-3017"
+  DEFAULT_CI_IMAGE: "quay.io/devtron/ci-runner:454be80a-138-3365"
   DEFAULT_CD_TIMEOUT: "3600"
   WF_CONTROLLER_INSTANCE_ID: "devtron-runner"
   CI_LOGS_KEY_PREFIX: "ci-artifacts"


### PR DESCRIPTION
we introduced this bug during azure blob support 